### PR TITLE
⚒ Slab designer fixes

### DIFF
--- a/awatif-ui/src/viewer/drawing/drawing.ts
+++ b/awatif-ui/src/viewer/drawing/drawing.ts
@@ -272,8 +272,20 @@ export function drawing({
     if (pointerDownAndMovedCount % 2 !== 0) return; // slow movements for (parametric) performance opt 5
 
     const newPoints = [...drawingObj.points.rawVal];
-    if (pointIndex !== undefined)
-      newPoints[pointIndex] = intersectWithPlane[0].point.toArray();
+    if (pointIndex !== undefined){
+      let newPosition = intersectWithPlane[0].point;
+      
+      if (event.ctrlKey) {
+        newPosition = new THREE.Vector3(
+          Math.round(newPosition.x),
+          Math.round(newPosition.y),
+          Math.round(newPosition.z)
+        );
+      }
+      
+      newPoints[pointIndex] = newPosition.toArray();
+      // newPoints[pointIndex] = intersectWithPlane[0].point.toArray();
+    }
     drawingObj.points.val = newPoints;
   });
 

--- a/awatif-ui/src/viewer/drawing/drawing.ts
+++ b/awatif-ui/src/viewer/drawing/drawing.ts
@@ -143,7 +143,7 @@ export function drawing({
 
     if (intersect.length) {
       let point = intersect[0].point;
-      if (event.ctrlKey) {
+      if (event.ctrlKey || event.metaKey) {
         point = new THREE.Vector3(
           Math.round(intersect[0].point.x),
           Math.round(intersect[0].point.y),
@@ -194,7 +194,7 @@ export function drawing({
     if (intersect.length) {
       let point = intersect[0].point;
 
-      if (event.ctrlKey) {
+      if (event.ctrlKey || event.metaKey) {
         point = new THREE.Vector3(
           Math.round(intersect[0].point.x),
           Math.round(intersect[0].point.y),
@@ -275,7 +275,7 @@ export function drawing({
     if (pointIndex !== undefined){
       let newPosition = intersectWithPlane[0].point;
       
-      if (event.ctrlKey) {
+      if (event.ctrlKey || event.metaKey) {
         newPosition = new THREE.Vector3(
           Math.round(newPosition.x),
           Math.round(newPosition.y),

--- a/examples/src/slab-designer/main.ts
+++ b/examples/src/slab-designer/main.ts
@@ -202,20 +202,17 @@ van.derive(() => {
 
 // When building data model changes, update base and solids geometry
 van.derive(() => {
-  if (building.points.val.length == 0) return;
   base.geometry = getBaseGeometry(
     building.points.val,
     building.slabs.val,
     building.columns.val
   );
 
-  if (building.columns.val.length > 0 || building.slabs.val[0][0].length > 2){
-    solidsMesh.geometry = getSolidsGeometry(
-      building.points.val,
-      building.slabs.val,
-      building.columns.val
-    );
-  }
+  solidsMesh.geometry = getSolidsGeometry(
+    building.points.val,
+    building.slabs.val,
+    building.columns.val
+  );
 
   objects3D.val = [...objects3D.rawVal]; // just to trigger re-rendering
 });
@@ -302,7 +299,7 @@ function getSolidsGeometry(
   if (columns.length > 0)
     solidGeoms.push(createColumnsGeometry(points, columns));
 
-  return mergeGeometries(solidGeoms);
+  return solidGeoms.length > 0 ? mergeGeometries(solidGeoms) : new BufferGeometry();
 
   function createSlabsGeometry(
     points: number[][],


### PR DESCRIPTION
This PR introduces:

- Grid snapping when moving points (triggered by Ctrl/Cmd key).

- Cross-platform support for modifier keys (Ctrl on Windows/Linux, Cmd on macOS).

- Fixed deletion of solids/base geometry.