### PR TITLE
Shell rema

### DIFF
--- a/awatif-fem/src/utils/getLocalStiffnessMatrix.ts
+++ b/awatif-fem/src/utils/getLocalStiffnessMatrix.ts
@@ -370,7 +370,7 @@ export function buildOrthotropicQin(
 }
 
 /** 3-node shell element local stiffness (18×18) */
-export function getLocalStiffnessMatrixShell(
+export function getLocalStiffnessMatrixMembrane(
   nodes: Node[],
   elementInputs: ElementInputs,
   index: number


### PR DESCRIPTION

[Kp_output.txt](https://github.com/user-attachments/files/20954268/Kp_output.txt)
Key changes include:

- **`getLocalStiffnessMatrixPlate` Implementation**: Translated the Fortran routine `us3_Kp.f90` to TypeScript, providing a function to compute the local stiffness matrix for plate (Bending + Shear) elements. This function now supports both isotropic and orthotropic material properties. [The]([us3_Km_output.txt](https://github.com/user-attachments/files/20954266/us3_Km_output.txt)) output has been numerically validated against `Kp_output.txt`. 

- **`getLocalStiffnessMatrixMembrane` Implementation**: Translated the Fortran routine `us3_Km.f90` to TypeScript, implementing the local stiffness matrix calculation for shell elements. This function now supports both isotropic and orthotropic material properties, mirroring the capabilities of `getLocalStiffnessMatrixPlate`. The output has been numerically validated against `us3_Km_output.txt`.
